### PR TITLE
Fix reminder cron fast-path for relative times

### DIFF
--- a/kabot/cron/parse.py
+++ b/kabot/cron/parse.py
@@ -18,6 +18,16 @@ _RELATIVE_PATTERNS = [
     (r"(?:in\s+)?(\d+)\s*days?", lambda m: int(m.group(1)) * 86400 * 1000),
 ]
 
+_REMINDER_INTENT_PATTERN = re.compile(
+    r"\b(ingatkan(?:\s+saya)?|remind me|set reminder|set a reminder|buat pengingat|pasang pengingat)\b",
+    re.IGNORECASE,
+)
+
+_REMINDER_CONNECTOR_PATTERN = re.compile(
+    r"\b(lagi|dalam|ke|untuk|to|in|after)\b",
+    re.IGNORECASE,
+)
+
 
 def parse_absolute_time_ms(value: str) -> int | None:
     """Parse an ISO-8601 or datetime string into milliseconds since epoch."""
@@ -38,3 +48,24 @@ def parse_relative_time_ms(value: str) -> int | None:
         if match:
             return converter(match)
     return None
+
+
+def parse_reminder_request(text: str) -> dict[str, int | str] | None:
+    """Parse reminder intent with relative time; return offset_ms/message or None."""
+    if not text or not _REMINDER_INTENT_PATTERN.search(text):
+        return None
+
+    offset_ms = parse_relative_time_ms(text)
+    if offset_ms is None:
+        return None
+
+    message = _REMINDER_INTENT_PATTERN.sub(" ", text)
+    for pattern, _ in _RELATIVE_PATTERNS:
+        message = re.sub(pattern, " ", message, flags=re.IGNORECASE)
+    message = _REMINDER_CONNECTOR_PATTERN.sub(" ", message)
+    message = re.sub(r"\s+", " ", message).strip()
+
+    if not message:
+        message = "Pengingat"
+
+    return {"offset_ms": offset_ms, "message": message}

--- a/tests/cron/test_parse.py
+++ b/tests/cron/test_parse.py
@@ -1,5 +1,5 @@
 # tests/cron/test_parse.py
-from kabot.cron.parse import parse_absolute_time_ms, parse_relative_time_ms
+from kabot.cron.parse import parse_absolute_time_ms, parse_relative_time_ms, parse_reminder_request
 
 def test_iso_timestamp():
     result = parse_absolute_time_ms("2026-02-15T10:00:00+07:00")
@@ -21,3 +21,22 @@ def test_natural_language():
 def test_invalid_returns_none():
     assert parse_absolute_time_ms("not a date") is None
     assert parse_relative_time_ms("not a time") is None
+
+
+def test_reminder_indonesian_with_message():
+    result = parse_reminder_request("ingatkan saya 2 menit lagi beli susu")
+    assert result == {"offset_ms": 120000, "message": "beli susu"}
+
+
+def test_reminder_indonesian_default_message():
+    result = parse_reminder_request("ingatkan 2 menit lagi")
+    assert result == {"offset_ms": 120000, "message": "Pengingat"}
+
+
+def test_reminder_english_with_message():
+    result = parse_reminder_request("remind me in 5 minutes to call mom")
+    assert result == {"offset_ms": 300000, "message": "call mom"}
+
+
+def test_reminder_non_relative_returns_none():
+    assert parse_reminder_request("ingatkan saya besok") is None


### PR DESCRIPTION
## Summary
- Add lightweight reminder intent parsing for relative times.
- Add fast-path scheduling to cron without LLM.
- Add reminder parsing tests (ID/EN).

## Test Plan
- [ ] PYTHONPATH=\"C:\Users\Arvy Kairi\Desktop\bot\kabot\.worktrees\reminder-cron-no-llm\" pytest \"C:\Users\Arvy Kairi\Desktop\bot\kabot\.worktrees\reminder-cron-no-llm\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)